### PR TITLE
fix vulnerable dependency of react-dev-scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,9 @@
     "webpack-manifest-plugin": "2.2.0",
     "workbox-webpack-plugin": "5.1.4"
   },
+  "resolutions": {
+    "immer": "^8.0.1"
+  },
   "scripts": {
     "start": "node scripts/start.js",
     "build": "node scripts/build.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5889,10 +5889,10 @@ ignore@^5.1.4:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
 
-immer@7.0.9:
-  version "7.0.9"
-  resolved "https://registry.yarnpkg.com/immer/-/immer-7.0.9.tgz#28e7552c21d39dd76feccd2b800b7bc86ee4a62e"
-  integrity sha512-Vs/gxoM4DqNAYR7pugIxi0Xc8XAun/uy7AQu4fLLqaTBHxjOP9pJ266Q9MWA/ly4z6rAFZbvViOtihxUZ7O28A==
+immer@7.0.9, immer@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-8.0.1.tgz#9c73db683e2b3975c424fb0572af5889877ae656"
+  integrity sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==
 
 import-cwd@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
ref https://github.com/facebook/create-react-app/issues/10411#issuecomment-781399779
```
celiyah@ce-y720-dev:~/Code/machete/react-ui$ yarn audit
yarn audit v1.22.5
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ high          │ Prototype Pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ immer                                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=8.0.1                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ react-dev-utils                                              │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ react-dev-utils > immer                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1603                        │
└───────────────┴──────────────────────────────────────────────────────────────┘
1 vulnerabilities found - Packages audited: 1819
Severity: 1 High
Done in 1.28s.
celiyah@ce-y720-dev:~/Code/machete/react-ui$ git checkout -b ops/fix_vulnerabilities
Switched to a new branch 'ops/fix_vulnerabilities'
celiyah@ce-y720-dev:~/Code/machete/react-ui$ git status
On branch ops/fix_vulnerabilities
nothing to commit, working tree clean
celiyah@ce-y720-dev:~/Code/machete/react-ui$ yarn install
yarn install v1.22.5
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@2.3.1: The platform "linux" is incompatible with this module.
info "fsevents@2.3.1" is an optional dependency and failed compatibility check. Excluding it from installation.
info fsevents@1.2.13: The platform "linux" is incompatible with this module.
info "fsevents@1.2.13" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
warning " > @testing-library/user-event@12.7.1" has unmet peer dependency "@testing-library/dom@>=7.21.4".
warning " > material-table@1.69.2" has unmet peer dependency "@date-io/core@1.3.6".
warning " > material-table@1.69.2" has incorrect peer dependency "@material-ui/core@4.0.1".
warning " > material-table@1.69.2" has incorrect peer dependency "react@16.8.4".
warning " > material-table@1.69.2" has incorrect peer dependency "react-dom@16.8.4".
warning "material-table > @material-ui/pickers@3.2.2" has unmet peer dependency "@date-io/core@^1.3.6".
warning "material-table > @material-ui/pickers@3.2.2" has incorrect peer dependency "react@^16.8.4".
warning "material-table > @material-ui/pickers@3.2.2" has incorrect peer dependency "react-dom@^16.8.4".
warning "material-table > react-beautiful-dnd@13.0.0" has incorrect peer dependency "react@^16.8.5".
warning "material-table > react-beautiful-dnd@13.0.0" has incorrect peer dependency "react-dom@^16.8.5".
[4/4] Building fresh packages...
success Saved lockfile.
Done in 8.39s.
celiyah@ce-y720-dev:~/Code/machete/react-ui$ yarn audit
yarn audit v1.22.5
0 vulnerabilities found - Packages audited: 1819
Done in 1.12s.
```